### PR TITLE
remove mixed type to support php7

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1190,7 +1190,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return \$this The current query, for fluid interface
      */
-    public function filterBy$singularPhpName(mixed \$$variableName = null, ?string \$comparison = null)
+    public function filterBy$singularPhpName(\$$variableName = null, ?string \$comparison = null)
     {
         if (null === \$comparison || \$comparison == Criteria::CONTAINS_ALL) {
             if (is_scalar(\$$variableName)) {
@@ -1240,7 +1240,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return \$this The current query, for fluid interface
      */
-    public function filterBy$singularPhpName(mixed \$$variableName = null, ?string \$comparison = null)
+    public function filterBy$singularPhpName(\$$variableName = null, ?string \$comparison = null)
     {
         \$this->filterBy$colPhpName(\$$variableName, \$comparison);
 


### PR DESCRIPTION
This restores PHP7.4 support for now. The `mixed` type was added in PHP 8.0 so we can only rely on the type in the docblock.
It's middle ground, I know.